### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@ DLIDEKeyboard
 
 Drop-in component for adding additional keyboard keys to both iPad/iPhone keyboards. Inspired by great [Pythonista](http://omz-software.com/pythonista/) application.
 
-##Usage
+## Usage
 The controls supports both iPad and iPhone platforms and can by applied to UITextView or UITextField.
 ```
 UITextView *textView = [[UITextView alloc] initWithFrame:self.view.bounds];
 [DLIDEKeyboardView attachToTextView:textView];
 ```
 
-##Screenshots
+## Screenshots
 ![iPad](https://github.com/garnett/DLIDEKeyboard/blob/master/Img/iPad.jpg?raw=true)   ![iPhone](https://github.com/garnett/DLIDEKeyboard/blob/master/Img/iPhone.png?raw=true)
 
-##License
+## License
 
 DLIDEKeyboard is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
